### PR TITLE
Added support for JSON

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -1,7 +1,7 @@
 import os
 import sqlite3
 import sys
-from scripts.file_helper import write_as_tsv
+from scripts.file_helper import *
 from utils import ROOT_DIR
 
 
@@ -17,53 +17,40 @@ def get_os_based_sqlite():
     elif os_check == 'darwin':
         return mac_tool
 
-
-def convert_to_tsv(db_path, tsv_file_path):
-    connection = sqlite3.connect(db_path)
-    cursor = connection.cursor()
-    cursor.execute('SELECT name FROM sqlite_master WHERE type = "table"')
-    tables = []
-    print('Tables in database are :: ')
-    for table_tuple in cursor.fetchall():
-        tables.append(table_tuple[0])
-        print(table_tuple[0])
-    for table in tables:
-        schema_query = 'pragma table_info("{0}")'.format(table)
-        schema = cursor.execute(schema_query).fetchall()
-        columns = []
-        for columns_tpl in schema:
-            columns.append(columns_tpl[1])
-        select_query = 'SELECT * from {0};'.format(table)
-        rows = cursor.execute(select_query).fetchall()
-        write_as_tsv(tsv_file_path + '/' + table + '.tsv', columns, rows)
-
-
 def print_help():
     help_str = """
         converter is a simple script to convert DB files to tsv (tab separated value)
         python converter.py <src-file-path> <destination-folder>
         example : 
-            python converter.py /home/user/Downloads/accounts.db /home/user/data/
+            python converter.py /home/user/Downloads/accounts.db /home/user/data/ json or tsv
     """
     print(help_str)
 
 
 if __name__ == '__main__':
     args = sys.argv
-    if len(args) < 3:
+    if len(args) < 4:
         print('Insufficient arguments')
         print_help()
-    elif len(args) == 3:
+    elif len(args) == 4:
         src_path = args[1]
         dest_dir = args[2]
+        file_type = args[3]
         if not os.path.exists(src_path):
             print('Given db file path is incorrect. This filepath doesn\'t exists ::' + src_path)
         case_name = src_path.split("/")[-3]
         folder_name = os.path.splitext(os.path.basename(src_path))[0]
         file_dir = dest_dir+"/"+case_name+"/"+folder_name
-        if not os.path.exists(file_dir):
-            os.makedirs(file_dir, exist_ok=True)
-        convert_to_tsv(src_path, file_dir)
+        if file_type == 'json':
+            file_dir = file_dir+'/'+'json'
+            if not os.path.exists(file_dir):
+                os.makedirs(file_dir, exist_ok=True)
+            convert_to_json(src_path, file_dir)
+        elif file_type == 'tsv':
+            file_dir = file_dir+'/'+'tsv'
+            if not os.path.exists(file_dir):
+                os.makedirs(file_dir, exist_ok=True)
+            convert_to_tsv(src_path, file_dir)
         pass
     else:
         print('Incorrect no. of arguments passed')

--- a/scripts/file_helper.py
+++ b/scripts/file_helper.py
@@ -1,3 +1,12 @@
+import sys
+import sqlite3
+
+def dict_factory(cursor, row):
+    d = {}
+    for idx, col in enumerate(cursor.description):
+        d[col[0]] = row[idx]
+    return d
+
 def write_as_tsv(filepath, columns, rows):
     tsv_file = open(filepath, "w+", encoding="utf-8")
     column_header = '\t'.join(columns)
@@ -9,3 +18,41 @@ def write_as_tsv(filepath, columns, rows):
         row_as_str = '\t'.join(str_tpl)
         tsv_file.write(row_as_str + '\n')
     tsv_file.close()
+
+def convert_to_tsv(db_path, tsv_file_path):
+    connection = sqlite3.connect(db_path)
+    cursor = connection.cursor()
+    cursor.execute('SELECT name FROM sqlite_master WHERE type = "table"')
+    tables = []
+    print('Tables in database are :: ')
+    for table_tuple in cursor.fetchall():
+        tables.append(table_tuple[0])
+        print(table_tuple[0])
+    for table in tables:
+        schema_query = 'pragma table_info("{0}")'.format(table)
+        schema = cursor.execute(schema_query).fetchall()
+        columns = []
+        for columns_tpl in schema:
+            columns.append(columns_tpl[1])
+        select_query = 'SELECT * from {0};'.format(table)
+        rows = cursor.execute(select_query).fetchall()
+        write_as_tsv(tsv_file_path + '/' + table + '.tsv', columns, rows)
+
+def convert_to_json(db_path, json_file_path):
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = dict_factory
+    cursor = connection.cursor()
+    cursor.execute('SELECT name FROM sqlite_master WHERE type = "table"')
+    tables = cursor.fetchall()
+    print('Tables in database are :: ')
+    for table_name in tables:
+            print (table_name['name'])
+            conn = sqlite3.connect(db_path)  
+            conn.row_factory = dict_factory
+            cur1 = conn.cursor()
+            cur1.execute("SELECT * FROM "+table_name['name'])
+            results = cur1.fetchall() 
+            # generate and save JSON files with the table name for each of the database tables
+            with open(json_file_path + '/' +table_name['name']+'.json', 'a') as the_file:
+                the_file.write(format(results).replace(" u'", "'").replace("'", "\""))
+    connection.close()


### PR DESCRIPTION
Added support for JSON resolving issue #22.
User can now run collector.py along with an option for either JSON or tsv and the converted files are then stored in `OpenMF/data/json/db_name` or `OpenMF/data/tsv/db_name`.
Screenshots are attached to show the results.
Different command for JSON and tsv files
![Screenshot from 2020-03-16 23-15-09](https://user-images.githubusercontent.com/26167974/76786484-4ae24e80-67dd-11ea-9bd5-7cb512aac529.png)
![Screenshot from 2020-03-16 23-15-22](https://user-images.githubusercontent.com/26167974/76786499-50d82f80-67dd-11ea-9c5c-579ea75b863d.png)

Data hierarchy of saved files
![Screenshot from 2020-03-16 23-14-06](https://user-images.githubusercontent.com/26167974/76786982-30f53b80-67de-11ea-960e-3517c5097847.png)
![Screenshot from 2020-03-16 23-14-26](https://user-images.githubusercontent.com/26167974/76786990-32beff00-67de-11ea-8669-0b092226625b.png)
