### PR TITLE
fix:know more btn in HomeLogo.js

### DIFF
--- a/React-frontend/src/components/core/HomeLogo.js
+++ b/React-frontend/src/components/core/HomeLogo.js
@@ -16,7 +16,7 @@ function Hl() {
                 <br />
                 <p className="h5 text-center mb-4">Open Source forensic tool for Android smartphones</p>
                 <div className="text-center">
-                <button color="elegant" href="https://github.com/scorelab/OpenMF//wiki">Know More</button>
+                  <a className="blue-text ml-1 font-weight-bolder" href="https://github.com/scorelab/OpenMF//wiki">Know More</a>
                 </div>
             </form>
             </div>


### PR DESCRIPTION
**fix**
know more button in HomeLogo.js is not working, it should be redirect the user to wiki page of scorelab, but it doesn't redirect the user.

**To Reproduce**
Steps to reproduce the behavior:
1. Replaced the button element with a achor tag and then providing some button styles to it.