### PR TITLE
[Backend] Fixed delete own account route

### DIFF
--- a/flask-backend/api/routes/user.py
+++ b/flask-backend/api/routes/user.py
@@ -188,7 +188,7 @@ def roleupdate():
     return 'You are not an admin.', 409
 
 
-@user.route('/delete', methods=['POST'])
+@user.route('/delete', methods=['DELETE'])
 @login_required
 def deleteuser():
     db.session.delete(current_user)

--- a/flask-backend/api/routes/user.py
+++ b/flask-backend/api/routes/user.py
@@ -157,6 +157,8 @@ def remove_user():
             email = str(req['email'])
         except:
             return 'Please provide all parameters', 409
+        if email == current_user.email:
+            return 'Cannot delete your own account', 401
         user = User.query.filter_by(admin=current_user.email).filter_by(email=email).first()
         if user:
             db.session.delete(user)
@@ -189,14 +191,6 @@ def roleupdate():
 @user.route('/delete', methods=['POST'])
 @login_required
 def deleteuser():
-    # Check if email is provided or not
-    try:
-        req = request.get_json()
-        email = str(req['email'])
-    except:
-        return 'please provide email', 400
-
-    user = User.query.filter_by(email=email).first()
-    db.session.delete(user)
+    db.session.delete(current_user)
     db.session.commit()
     return 'user deleted', 202


### PR DESCRIPTION
# Description

PR consists of the following :-
1. Fixed the delete own account route to delete the current user without requiring any email.
2. Added a check in delete user route so that an admin cannot delete his own account.

Fixes #105 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Postman

**Test Configuration**:

- Windows 10

![1](https://user-images.githubusercontent.com/45410599/109275680-12475380-783b-11eb-9535-6242b9b3466a.png)

![2](https://user-images.githubusercontent.com/45410599/109275700-183d3480-783b-11eb-9496-6e870c4d1388.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
