### PR TITLE
[Backend] Added password strength validation while creating user

### DIFF
--- a/flask-backend/api/helpers/helpers.py
+++ b/flask-backend/api/helpers/helpers.py
@@ -1,0 +1,11 @@
+from password_strength import PasswordPolicy
+
+def check_password_strength(password):
+  policy = PasswordPolicy.from_names(
+    length=8,  # min length: 8
+    uppercase=1,  # need min. 1 uppercase letter
+    numbers=1,  # need min. 1 digit
+    special=1,  # need min. 1 special character
+  )
+  result = policy.test(password)
+  return result

--- a/flask-backend/api/routes/user.py
+++ b/flask-backend/api/routes/user.py
@@ -6,6 +6,8 @@ from ..models.models import User, UserSchema
 from werkzeug.security import generate_password_hash, check_password_hash
 from .. import db
 from sqlalchemy import update
+from ..helpers.helpers import check_password_strength
+
 user_schema = UserSchema()
 users_schema = UserSchema(many=True)
 
@@ -92,6 +94,10 @@ def create_user(): # Add only admin can create functionality, once deployed on a
     except KeyError as err:
         return f'please provide {str(err)}', 400
 
+    validations = check_password_strength(password)
+    if validations:
+        return 'Weak password. Make sure it contains atleast 1 uppercase letter, 1 digit and 1 special character', 400
+
     timestamp = int(time.time())
     
     user = User.query.filter_by(email=email).first()
@@ -122,6 +128,10 @@ def add_users():
         except:
             return 'Please provide all parameters', 409
         user = User.query.filter_by(email=email).first()
+
+        validations = check_password_strength(password)
+        if validations:
+            return 'Weak password. Make sure it contains atleast 1 uppercase letter, 1 digit and 1 special character', 400
 
         if user:
             return 'Email address already exists', 409

--- a/flask-backend/requirements.txt
+++ b/flask-backend/requirements.txt
@@ -1,5 +1,6 @@
 astroid==2.4.2
 click==7.1.2
+colorama==0.4.4
 Flask==1.1.1
 Flask-Cors==3.0.10
 Flask-Login==0.5.0
@@ -13,11 +14,13 @@ MarkupSafe==1.1.1
 marshmallow==3.7.1
 marshmallow-sqlalchemy==0.23.1
 mccabe==0.6.1
+password-strength==0.0.3.post2
 pdfkit==0.6.1
 pylint==2.5.3
 six==1.15.0
 SQLAlchemy==1.3.18
 toml==0.10.1
+typed-ast==1.4.2
 typing==3.7.4.3
 Werkzeug==1.0.1
 wrapt==1.12.1


### PR DESCRIPTION
# Description

Added password strength validation while creating a user. A Valid password contains at least 1 uppercase character, 1 digit, and 1 special digit.

Fixes #125 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Try creating a user with a weak password.

**Test Configuration**:

- Windows 10
- Postman

![screen-capture](https://user-images.githubusercontent.com/45410599/109383660-d6c98980-790d-11eb-9ac5-cd3dcef820f7.gif)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
