### PR TITLE
[Backend] Fixed cases list and count routes to show info from 'data' folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ ENV/
 
 # SQLite data
 flask-backend/api/db.sqlite3
+
+data/

--- a/flask-backend/api/routes/case.py
+++ b/flask-backend/api/routes/case.py
@@ -12,16 +12,51 @@ cases_schema = CaseSchema(many=True)
 
 case = Blueprint('case', __name__, url_prefix='/case')
 
+dirname = os.path.dirname(__file__)
+cases_data_path = os.path.join(dirname, '../../../data/')
+
+
 @case.route('/count', methods=["GET"])
 def count():
-    return jsonify({'status':200,
-                    'total_users':Case.query.count()})
+    try:
+        os.chdir('../../..')
+        os.chdir(ROOT_DIR)
+        cases = os.listdir(cases_data_path)
+        print(cases_data_path, cases)
+    except FileNotFoundError as err:
+        # If data folder is not found, return empty list as no cases have been created
+        response = {
+            'success': True,
+            'data': 0,
+        }
+        return jsonify(response), 200
+    response = {
+        'success': True,
+        'data': len(cases),
+    }
+    return jsonify(response), 200
+
 
 @case.route('/list', methods=["GET"])
 def list():
-    all_cases = Case.query.order_by(Case.timestamp).all()
-    result = cases_schema.dump(all_cases)
-    return jsonify(result)
+    try:
+        os.chdir('../../..')
+        os.chdir(ROOT_DIR)
+        cases = os.listdir(cases_data_path)
+        print(cases_data_path, cases)
+    except FileNotFoundError as err:
+        # If data folder is not found, return empty list as no cases have been created
+        response = {
+            'success': True,
+            'data': [],
+        }
+        return jsonify(response), 200
+    response = {
+        'success': True,
+        'data': cases,
+    }
+    return jsonify(response), 200
+
 
 @case.route('/delete', methods=['POST'])
 def deletecase():
@@ -41,6 +76,7 @@ def deletecase():
     db.session.commit()
     return 'case deleted', 202
 
+
 @case.route('/open/<case_name>', methods=["GET"])
 def openCase(case_name):
     os.chdir('../../..')
@@ -49,6 +85,7 @@ def openCase(case_name):
     files = os.listdir(path)
     return files
 
+
 @case.route('/list-files/<case_name>/<folder_name>', methods=["GET"])
 def openFolder(case_name, folder_name):
     os.chdir('../../..')
@@ -56,6 +93,7 @@ def openFolder(case_name, folder_name):
     os.chdir(ROOT_DIR)
     files = os.listdir(path)
     return files
+
 
 @case.route('/list-files/<case_name>/<folder_name>/<file_name>', methods=["GET"])
 def openFile(case_name, folder_name, file_name):

--- a/flask-backend/api/routes/case.py
+++ b/flask-backend/api/routes/case.py
@@ -22,7 +22,6 @@ def count():
         os.chdir('../../..')
         os.chdir(ROOT_DIR)
         cases = os.listdir(cases_data_path)
-        print(cases_data_path, cases)
     except FileNotFoundError as err:
         # If data folder is not found, return empty list as no cases have been created
         response = {
@@ -43,7 +42,6 @@ def list():
         os.chdir('../../..')
         os.chdir(ROOT_DIR)
         cases = os.listdir(cases_data_path)
-        print(cases_data_path, cases)
     except FileNotFoundError as err:
         # If data folder is not found, return empty list as no cases have been created
         response = {


### PR DESCRIPTION
# Description

Fixed the cases list and count routes to show info from the 'data' folder instead of db, similar to other case routes.

Fixes #153 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Try running case/list and case/count routes.

**Test Configuration**:

- Ubuntu
- Postman

![1](https://user-images.githubusercontent.com/45410599/110576545-f8850500-8186-11eb-9fc2-593aeae1be90.png)
![2](https://user-images.githubusercontent.com/45410599/110576550-fb7ff580-8186-11eb-8f45-25f22100110b.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
