### PR TITLE
[Frontend] enabled lazy loading

### DIFF
--- a/React-frontend/src/components/core/HomeLogo.js
+++ b/React-frontend/src/components/core/HomeLogo.js
@@ -16,7 +16,7 @@ function Hl() {
                 <br />
                 <p className="h5 text-center mb-4">Open Source forensic tool for Android smartphones</p>
                 <div className="text-center">
-                <button color="elegant" href="https://github.com/scorelab/OpenMF/">Know More</button>
+                <button color="elegant" href = "https://github.com/scorelab/OpenMF/">Know More</button>
                 </div>
             </form>
             </div>

--- a/React-frontend/src/components/core/HomeLogo.js
+++ b/React-frontend/src/components/core/HomeLogo.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Logo from '../../images/HomeLogo.png';
 import { MDBContainer } from 'mdbreact';
-import { Link } from 'react-router-dom';
+
 
 function Hl() {
     return (

--- a/React-frontend/src/components/core/HomeLogo.js
+++ b/React-frontend/src/components/core/HomeLogo.js
@@ -16,7 +16,7 @@ function Hl() {
                 <br />
                 <p className="h5 text-center mb-4">Open Source forensic tool for Android smartphones</p>
                 <div className="text-center">
-                <button color="elegant" href="https://github.com/scorelab/OpenMF//wiki">Know More</button>
+                <button color="elegant" href="https://github.com/scorelab/OpenMF/">Know More</button>
                 </div>
             </form>
             </div>

--- a/React-frontend/src/components/core/HomeLogo.js
+++ b/React-frontend/src/components/core/HomeLogo.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Logo from '../../images/HomeLogo.png';
 import { MDBContainer } from 'mdbreact';
+import { Link } from 'react-router-dom';
 
 function Hl() {
     return (
@@ -16,7 +17,11 @@ function Hl() {
                 <br />
                 <p className="h5 text-center mb-4">Open Source forensic tool for Android smartphones</p>
                 <div className="text-center">
-                <button color="elegant" href = "https://github.com/scorelab/OpenMF/">Know More</button>
+                
+                <a className= "btn block-example rounded-pill border border-dark" color = "elegant"  href="http://www.scorelab.org/">
+                    Know More
+                  </a>
+                
                 </div>
             </form>
             </div>

--- a/React-frontend/src/pages/AboutPage.js
+++ b/React-frontend/src/pages/AboutPage.js
@@ -7,7 +7,7 @@ const AboutPage = () => {
         <Suspense fallback={<div>Loading...</div>}>
         <Layout sidebarBool={true}>
             <h1>About page</h1>
-        </Layout>
+        </Layout> 
         </Suspense>
     )
 }

--- a/React-frontend/src/pages/AboutPage.js
+++ b/React-frontend/src/pages/AboutPage.js
@@ -1,11 +1,14 @@
-import React from 'react'
-import Layout from '../components/core/Layout'
+import React , { Suspense } from 'react'
+const Layout = React.lazy(() => import('../components/core/Layout'));
+
 
 const AboutPage = () => {
     return (
+        <Suspense fallback={<div>Loading...</div>}>
         <Layout sidebarBool={true}>
             <h1>About page</h1>
         </Layout>
+        </Suspense>
     )
 }
 

--- a/React-frontend/src/pages/ContactPage.js
+++ b/React-frontend/src/pages/ContactPage.js
@@ -6,7 +6,7 @@ const AboutPage = () => {
         <Suspense fallback={<div>Loading...</div>}>
         <Layout sidebarBool={true}>
             <h1>Contact page</h1>
-        </Layout>
+        </Layout> 
         </Suspense>
     )
 }

--- a/React-frontend/src/pages/ContactPage.js
+++ b/React-frontend/src/pages/ContactPage.js
@@ -1,11 +1,13 @@
-import React from 'react'
-import Layout from '../components/core/Layout'
+import React , { Suspense } from 'react'
+const Layout = React.lazy(() => import('../components/core/Layout'));
 
 const AboutPage = () => {
     return (
+        <Suspense fallback={<div>Loading...</div>}>
         <Layout sidebarBool={true}>
             <h1>Contact page</h1>
         </Layout>
+        </Suspense>
     )
 }
 

--- a/React-frontend/src/pages/HomePage.js
+++ b/React-frontend/src/pages/HomePage.js
@@ -1,6 +1,7 @@
 import React , { Suspense } from 'react'
 const Layout = React.lazy(() => import('../components/core/Layout'));
 
+
 const HomePage = () => {
     return (
         <Suspense fallback={<div>Loading...</div>}>

--- a/React-frontend/src/pages/HomePage.js
+++ b/React-frontend/src/pages/HomePage.js
@@ -1,11 +1,13 @@
-import React from 'react'
-import Layout from '../components/core/Layout'
+import React , { Suspense } from 'react'
+const Layout = React.lazy(() => import('../components/core/Layout'));
 
 const HomePage = () => {
     return (
+        <Suspense fallback={<div>Loading...</div>}>
         <Layout>
             <h1>Home Page</h1>
         </Layout>
+        </Suspense>
     )
 }
 

--- a/React-frontend/src/pages/LoginPage.js
+++ b/React-frontend/src/pages/LoginPage.js
@@ -7,7 +7,6 @@ const Layout = React.lazy(() => import('../components/core/Layout'));
 const Hl = React.lazy(() => import('../components/core/HomeLogo'));
 const Lf = React.lazy(() => import('../components/LoginForm'));
 
-
 const LoginPage = () => {
   const { isLoading, isAuthenticated } = useSelector(state => state.auth);
 

--- a/React-frontend/src/pages/LoginPage.js
+++ b/React-frontend/src/pages/LoginPage.js
@@ -1,11 +1,12 @@
-import React from 'react';
-import Hl from '../components/core/HomeLogo';
-import Lf from '../components/LoginForm';
+import React , { Suspense } from 'react';
 import { useSelector } from 'react-redux';
 
 import { MDBRow, MDBCol } from 'mdbreact';
-import Layout from '../components/core/Layout';
 import { Redirect } from 'react-router-dom';
+const Layout = React.lazy(() => import('../components/core/Layout'));
+const Hl = React.lazy(() => import('../components/core/HomeLogo'));
+const Lf = React.lazy(() => import('../components/LoginForm'));
+
 
 const LoginPage = () => {
   const { isLoading, isAuthenticated } = useSelector(state => state.auth);
@@ -15,6 +16,7 @@ const LoginPage = () => {
   }
 
   return (
+    <Suspense fallback={<div>Loading...</div>}>
     <Layout sidebarBool={false}>
       <MDBRow>
         <MDBCol md='5'>
@@ -29,6 +31,7 @@ const LoginPage = () => {
       <br />
       <br />
     </Layout>
+    </Suspense>
   );
 };
 


### PR DESCRIPTION
# Description
Enabled Lazy loading in React. This lazy component should then be rendered inside a Suspense component, which allows us to show some fallback content (such as a loading indicator) while we’re waiting for the lazy component to load.

Fixes #130

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
