### PR TITLE
Open method to Open case files

### DIFF
--- a/React-frontend/src/components/Management/FilterCase.js
+++ b/React-frontend/src/components/Management/FilterCase.js
@@ -78,6 +78,16 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "row",
     paddingLeft: "10px",
   },
+  caseText: {
+    fontWeight: "bold",
+  },
+  copyButton: {
+    color: theme.palette.text.secondary,
+    margin: theme.spacing(1.5, 0),
+    width: '30%',
+    "&:hover": {
+    },
+  }
 }));
 
 const StyledTableCell = withStyles((theme) => ({
@@ -137,6 +147,25 @@ function FilterCase() {
       dispatch(loadTagCases(tags));
     }
   }
+
+  // Function to hancle copy and open file
+  function callCase(id) {
+    var caseLink = "file://" + id;
+    var copyText = document.createElement("input");
+    copyText.value = caseLink;
+    document.body.appendChild(copyText);
+    copyText.select();
+    document.execCommand("copy");
+    alert("Copied the text: \n" + copyText.value + "\nto clipboard.\n\nPlease paste in new window");
+    window.open("", "_blank");
+
+  }
+
+  // Function to return case tag
+  function getCaseName(str) {
+    return str.substring(str.lastIndexOf("/") + 1);
+  }
+
   return (
     <Container component="main" className={classes.root}>
       <Container>
@@ -278,7 +307,8 @@ function FilterCase() {
                 <TableHead>
                   <StyledTableRow>
                     <StyledTableCell align="left">Index</StyledTableCell>
-                    <StyledTableCell align="left">Case Files</StyledTableCell>
+                    <StyledTableCell align="left">Case Tag</StyledTableCell>
+                    <StyledTableCell align="left">Copy path to Clipboard</StyledTableCell>
                   </StyledTableRow>
                 </TableHead>
 
@@ -292,8 +322,24 @@ function FilterCase() {
                           </StyledTableCell>
                         }
                         {
-                          <StyledTableCell component="th" scope="row">
-                            {row}
+                          <StyledTableCell component="th" scope="row"
+                            className={classes.caseText}
+                          >
+                            {getCaseName(row)}
+                          </StyledTableCell>
+                        }
+                        {
+                          <StyledTableCell component="th" scope="row" className={classes.copyButton}>
+                            <Button
+                              variant="contained"
+                              color="primary"
+                              className={classes.submit}
+                              style={{ width: "10%" }}
+                              onClick={() => {
+                                callCase(row)}}
+                            >
+                              Copy
+                            </Button>
                           </StyledTableCell>
                         }
                       </StyledTableRow>

--- a/React-frontend/src/components/Management/Keywordsearch.js
+++ b/React-frontend/src/components/Management/Keywordsearch.js
@@ -73,6 +73,16 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "row",
     paddingLeft: "10px",
   },
+  caseText: {
+    fontWeight: "bold",
+  },
+  copyButton: {
+    color: theme.palette.text.secondary,
+    margin: theme.spacing(1.5, 0),
+    width: '30%',
+    "&:hover": {
+    },
+  }
 }));
 
 const StyledTableCell = withStyles((theme) => ({
@@ -151,6 +161,25 @@ function Keywordsearch() {
       }
     }
   }
+  
+  // Function to hancle copy and open file
+  function callCase(id) {
+    var caseLink = "file://" + id;
+    var copyText = document.createElement("input");
+    copyText.value = caseLink;
+    document.body.appendChild(copyText);
+    copyText.select();
+    document.execCommand("copy");
+    alert("Copied the text: \n" + copyText.value + "\nto clipboard.\n\nPlease paste in new window");
+    window.open("", "_blank");
+
+  }
+
+  // Function to return case tag
+  function getCaseName(str) {
+    return str.substring(str.lastIndexOf("/") + 1);
+  }
+
 
   return (
     <Container component="main" className={classes.root}>
@@ -251,7 +280,8 @@ function Keywordsearch() {
                 <TableHead>
                   <StyledTableRow>
                     <StyledTableCell align="left">Index</StyledTableCell>
-                    <StyledTableCell align="left">Case Files</StyledTableCell>
+                    <StyledTableCell align="left">Case Tag</StyledTableCell>
+                    <StyledTableCell align="left">Copy path to Clipboard</StyledTableCell>
                   </StyledTableRow>
                 </TableHead>
 
@@ -265,8 +295,24 @@ function Keywordsearch() {
                           </StyledTableCell>
                         }
                         {
-                          <StyledTableCell component="th" scope="row">
-                            {value}
+                          <StyledTableCell component="th" scope="row"
+                            className={classes.caseText}
+                          >
+                            {getCaseName(value)}
+                          </StyledTableCell>
+                        }
+                        {
+                          <StyledTableCell component="th" scope="row" className={classes.copyButton}>
+                            <Button
+                              variant="contained"
+                              color="primary"
+                              className={classes.submit}
+                              style={{ width: "10%" }}
+                              onClick={() => {
+                                callCase(value)}}
+                            >
+                              Copy
+                            </Button>
                           </StyledTableCell>
                         }
                       </StyledTableRow>


### PR DESCRIPTION
# Description

For [security reasons](https://textslashplain.com/2019/10/09/navigating-to-file-urls/), internal file paths were inaccessible to the visitor and user. So there was no adequate way for the Management to open case files after looking for them in the **Keyword Search** and **Filter Search** sections of _Analytics_. 

This issue was fixed by copying the file path to the clipboard and allowing the user to open the same in a new tab as a browser as a file explorer as most browsers natively support `.txt`, `.pdf`, `.tsv`, etc formats.

Fixes #284

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With multiple test cases, from multiple filters and keywords, this feature did not break.

Also, include screenshots for the verification and reviewing purpose.

* Filter Cases
<img width="1671" alt="Screenshot 2022-08-08 at 2 51 51 PM" src="https://user-images.githubusercontent.com/76054330/183385168-4086bd0f-fdb4-4eda-926f-5570024e6f7f.png">

* Keyword Search
<img width="1676" alt="Screenshot 2022-08-08 at 2 51 38 PM" src="https://user-images.githubusercontent.com/76054330/183385218-242be807-fe28-49cf-a393-1728de573082.png">


## Demo

https://user-images.githubusercontent.com/76054330/183386215-2420be1c-a2de-43a7-9189-ed95e4d343ff.mov




# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works **(N/A)**
- [ ] New and existing unit tests pass locally with my changes **(N/A)**
- [ ] Any dependent changes have been merged and published in downstream modules **(N/A)**
