### PR TITLE
Download the JSON as .json and .xml

### DIFF
--- a/React-frontend/src/components/Management/CaseTreeView.js
+++ b/React-frontend/src/components/Management/CaseTreeView.js
@@ -280,6 +280,7 @@ function CaseTreeView() {
                         disableElevation
                         disableRipple
                         disableFocusRipple
+                        style={{ marginLeft: '1rem' }}
                         onClick={() => {
                             const data = document.getElementById('PrettyJSON').innerText
                             const dataToSave = data.slice(20, data.length)

--- a/React-frontend/src/components/Management/CaseTreeView.js
+++ b/React-frontend/src/components/Management/CaseTreeView.js
@@ -147,12 +147,42 @@ function CaseTreeView() {
         </TreeItem>
     )
 
+    // Manage JsonPretty component
+    function getJSON() {
+        const data = document.getElementById('PrettyJSON').innerText
+        const dataToSave = data.slice(20, data.length)
+        const blob = new Blob([dataToSave], { type: 'text/plain;charset=utf-8' })
+        saveAs(blob, 'caseTree.json')
+    }
+
     // Save case function
     function saveAs(blob, fileName) {
         const link = document.createElement('a')
         link.href = window.URL.createObjectURL(blob)
         link.download = fileName
         link.click()
+    }
+
+    // Convert to XML function
+    function OBJtoXML(obj) {
+        var xml = '';
+        for (var prop in obj) {
+            xml += obj[prop] instanceof Array ? '' : "<" + prop + ">";
+            if (obj[prop] instanceof Array) {
+                for (var array in obj[prop]) {
+                    xml += "<" + prop + ">";
+                    xml += OBJtoXML(new Object(obj[prop][array]));
+                    xml += "</" + prop + ">";
+                }
+            } else if (typeof obj[prop] == "object") {
+                xml += OBJtoXML(new Object(obj[prop]));
+            } else {
+                xml += obj[prop];
+            }
+            xml += obj[prop] instanceof Array ? '' : "</" + prop + ">";
+        }
+        var xml = xml.replace(/<\/?[0-9]{1,}>/g, '');
+        return xml
     }
 
     // Check if case reducer is loaded or not
@@ -231,6 +261,19 @@ function CaseTreeView() {
 
                     <div style={{ height: '1vh' }}></div>
 
+                    {/* Download as JSON */}
+                    <Button
+                        variant="contained"
+                        color="secondary"
+                        disableElevation
+                        disableRipple
+                        disableFocusRipple
+                        onClick={() => getJSON()}
+                    >
+                        Download as JSON
+                    </Button>
+
+                    {/* Download as XML */}
                     <Button
                         variant="contained"
                         color="secondary"
@@ -239,13 +282,13 @@ function CaseTreeView() {
                         disableFocusRipple
                         onClick={() => {
                             const data = document.getElementById('PrettyJSON').innerText
-                            // Remove "Pretty Json Format" from data
                             const dataToSave = data.slice(20, data.length)
-                            const blob = new Blob([dataToSave], { type: 'text/plain;charset=utf-8' })
-                            saveAs(blob, 'caseTree.json')
+                            const blob = new Blob([OBJtoXML(JSON.parse(dataToSave))],
+                                { type: 'text/plain;charset=utf-8' })
+                            saveAs(blob, 'caseTree.xml')
                         }}
                     >
-                        Download as JSON
+                        Download as XML
                     </Button>
                 </Grid>
             </Grid>

--- a/React-frontend/src/components/Management/CaseTreeView.js
+++ b/React-frontend/src/components/Management/CaseTreeView.js
@@ -133,7 +133,7 @@ function CaseTreeView() {
             label={
                 <>
                     <Tooltip title={nodes.name} arrow>
-                        <span style={{fontSize: '.8rem'}}>{nodes.name}</span>
+                        <span style={{ fontSize: '.8rem' }}>{nodes.name}</span>
                     </Tooltip>
                     <span className={classes.dullText}>
                         {nodes.size}
@@ -146,6 +146,14 @@ function CaseTreeView() {
             {Array.isArray(nodes.children) ? nodes.children.map((node) => renderTree(node)) : null}
         </TreeItem>
     )
+
+    // Save case function
+    function saveAs(blob, fileName) {
+        const link = document.createElement('a')
+        link.href = window.URL.createObjectURL(blob)
+        link.download = fileName
+        link.click()
+    }
 
     // Check if case reducer is loaded or not
     return (
@@ -176,7 +184,7 @@ function CaseTreeView() {
                                     setCaseName('')
                                 }}
                             >
-                                {(!caseReducer.isLoading) ? (<span>Create Case Tree </span>): (<span>Creating...</span>)}
+                                {(!caseReducer.isLoading) ? (<span>Create Case Tree </span>) : (<span>Creating...</span>)}
                             </Button>
                         </InputAdornment>
                     )
@@ -198,27 +206,47 @@ function CaseTreeView() {
                                 {renderTree(caseReducer.caseTree)}
                             </TreeView>
                         ) : (caseReducer.error) ? (
-                            <span style={{fontSize: '.8rem'}}>{caseReducer.error}</span>
+                            <span style={{ fontSize: '.8rem' }}>{caseReducer.error}</span>
                         ) : (
-                            <span style={{fontSize: '.8rem'}}>Please Provide Case Name.</span>
+                            <span style={{ fontSize: '.8rem' }}>Please Provide Case Name.</span>
                         )
                     }
 
                 </Grid>
-                <Grid item xs={12} md={10} className={classes.rightUpperPart}>
+                <Grid item xs={12} md={10} className={classes.rightUpperPart} >
 
                     {/* Render CaseTree in Pretty Json format */}
-                    {
-                        (caseReducer.isLoading || !caseReducer.caseTree ||fileReducer.isLoading || !fileReducer.file || !fileReducer.fileType) ? (
-                            <JsonPretty data={caseReducer.caseTree}/>
-                        ) : (fileReducer.fileType === 'report' || fileReducer.fileType === 'txt') ? (
-                            <ShowTXT data={fileReducer.file} className={classes.rightPart}/>
-                        ) : (fileReducer.fileType === 'tsv') ? (
-                            <ShowTSV data={fileReducer.file} className={classes.rightPart}/>) : (
+                    <div id="PrettyJSON">
+                        {
+                            (caseReducer.isLoading || !caseReducer.caseTree || fileReducer.isLoading || !fileReducer.file || !fileReducer.fileType) ? (
+                                <JsonPretty data={caseReducer.caseTree} />
+                            ) : (fileReducer.fileType === 'report' || fileReducer.fileType === 'txt') ? (
+                                <ShowTXT data={fileReducer.file} className={classes.rightPart} />
+                            ) : (fileReducer.fileType === 'tsv') ? (
+                                <ShowTSV data={fileReducer.file} className={classes.rightPart} />) : (
                                 <pre className={classes.preStyle}>{fileReducer.file}</pre>
                             )
-                    }
+                        }
+                    </div>
 
+                    <div style={{ height: '1vh' }}></div>
+
+                    <Button
+                        variant="contained"
+                        color="secondary"
+                        disableElevation
+                        disableRipple
+                        disableFocusRipple
+                        onClick={() => {
+                            const data = document.getElementById('PrettyJSON').innerText
+                            // Remove "Pretty Json Format" from data
+                            const dataToSave = data.slice(20, data.length)
+                            const blob = new Blob([dataToSave], { type: 'text/plain;charset=utf-8' })
+                            saveAs(blob, 'caseTree.json')
+                        }}
+                    >
+                        Download as JSON
+                    </Button>
                 </Grid>
             </Grid>
 


### PR DESCRIPTION
# Description

Case Tree visible as Management in _CaseTreeView_ in **Pretty Json Format**, can now be downloaded as both `.json` and `.xml` format.

Fixes #267 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Only the cases' data is extracted in _JSON_ object format
- [x] Only the cases' data is extracted in _XML_ language format

Also, include screenshots for the verification and reviewing purpose.
<img width="1291" alt="Screenshot 2022-09-05 at 11 52 06 PM" src="https://user-images.githubusercontent.com/76054330/188499977-3e6dc770-9fcd-4a40-a2a5-9aaf541ad707.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works **(N/A)**
- [ ] New and existing unit tests pass locally with my changes **(N/A)**
- [ ] Any dependent changes have been merged and published in downstream modules **(N/A)**

Note: _Warnings_ in Dev Mode console for parsing and converting `.json` to `.xml`
